### PR TITLE
Bumped minikube to 1.7.3

### DIFF
--- a/minikube/minikube.spec
+++ b/minikube/minikube.spec
@@ -1,5 +1,5 @@
 Name:          minikube
-Version:       1.7.2
+Version:       1.7.3
 Release:       1%{?dist}
 Summary:       Minikube is a tool that makes it easy to run Kubernetes locally
 
@@ -28,6 +28,9 @@ mkdir -p %{buildroot}/%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Thu Feb 20 2020 Johan Kok <johan@fedoraproject.org> - 1.7.3-1
+- Bump to 1.7.3
+
 * Mon Feb 17 2020 Sergi Jimenez <tripledes@fedoraproject.org> - 1.7.2-1
 - Bump to 1.7.2
 


### PR DESCRIPTION
Hi, minikube 1.7.3 was released today, I updated the `minikube.spec` file.