### PR TITLE
Bump minikube to 1.9.2

### DIFF
--- a/docker-machine-driver-kvm2/docker-machine-driver-kvm2.spec
+++ b/docker-machine-driver-kvm2/docker-machine-driver-kvm2.spec
@@ -1,5 +1,5 @@
 Name:          docker-machine-driver-kvm2
-Version:       1.7.3
+Version:       1.9.2
 Release:       1%{?dist}
 Summary:       docker-machine KVM driver v2 for minikube
 
@@ -27,6 +27,9 @@ mkdir -p %{buildroot}/%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Thu Apr 30 2020 Johan Kok <johan@fedoraproject.org> - 1.9.2-1
+- Bump to 1.9.2
+
 * Thu Feb 20 2020 Sergi Jimenez <tripledes@fedoraproject.org> - 1.7.3-1
 - Bump to 1.7.3
 

--- a/minikube/minikube.spec
+++ b/minikube/minikube.spec
@@ -1,5 +1,5 @@
 Name:          minikube
-Version:       1.7.3
+Version:       1.9.2
 Release:       1%{?dist}
 Summary:       Minikube is a tool that makes it easy to run Kubernetes locally
 
@@ -28,6 +28,9 @@ mkdir -p %{buildroot}/%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Thu Apr 30 2020 Johan Kok <johan@fedoraproject.org> - 1.9.2-1
+- Bump to 1.9.2
+
 * Thu Feb 20 2020 Johan Kok <johan@fedoraproject.org> - 1.7.3-1
 - Bump to 1.7.3
 


### PR DESCRIPTION
Hi,

Minikube 1.9.2 was released and I've updated the spec files. Would it also be possible to enable Fedora 32 for building in your copr repository? Gracias!