### PR TITLE
Bumped minikube to 1.10.1

### DIFF
--- a/docker-machine-driver-kvm2/docker-machine-driver-kvm2.spec
+++ b/docker-machine-driver-kvm2/docker-machine-driver-kvm2.spec
@@ -1,5 +1,5 @@
 Name:          docker-machine-driver-kvm2
-Version:       1.9.2
+Version:       1.10.1
 Release:       1%{?dist}
 Summary:       docker-machine KVM driver v2 for minikube
 
@@ -27,6 +27,9 @@ mkdir -p %{buildroot}/%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sun May 17 2020 Johan Kok <johan@fedoraproject.org> - 1.10.1-1
+- Bump to 1.10.1
+
 * Thu Apr 30 2020 Johan Kok <johan@fedoraproject.org> - 1.9.2-1
 - Bump to 1.9.2
 

--- a/minikube/minikube.spec
+++ b/minikube/minikube.spec
@@ -1,5 +1,5 @@
 Name:          minikube
-Version:       1.9.2
+Version:       1.10.1
 Release:       1%{?dist}
 Summary:       Minikube is a tool that makes it easy to run Kubernetes locally
 
@@ -28,6 +28,9 @@ mkdir -p %{buildroot}/%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sun May 17 2020 Johan Kok <johan@fedoraproject.org> - 1.10.1-1
+- Bump to 1.10.1
+
 * Thu Apr 30 2020 Johan Kok <johan@fedoraproject.org> - 1.9.2-1
 - Bump to 1.9.2
 


### PR DESCRIPTION
And minikube 1.10.1 was released. The updated .spec-files are in this pull request. Thank you!